### PR TITLE
docs: align documentation with current command and config behavior

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ Use the following patterns directly in the chat window to apply styles:
 > * **Links:** Only `https://` URLs are supported for security.
 > * **Colors:** Presets (e.g., `pink`) are defined in the mod configuration.
 > * **Fonts:** The `path` requires a namespaced ID (e.g., `minecraft:alt`).
-> * **More Info:** For advanced syntax, style combinations, and detailed rules, refer to `/ec help style` or the [StyleWiki](https://hanhy06.github.io/embellish-chat/site/style/StyleSystem/).
+> * **More Info:** For advanced syntax, style combinations, and detailed rules, refer to `/embellish-chat help style` or the [StyleWiki](https://hanhy06.github.io/embellish-chat/site/style/StyleSystem/).
 
 ---
 
@@ -82,16 +82,15 @@ Use the following patterns directly in the chat window to apply styles:
 
 * **`/embellish-chat reload`** Reloads all configuration files under `/config/embellish-chat/` immediately.
 * **`/embellish-chat ban/pardon <player>`** Blocks or restores a player's access to all mod features.
-* **`/embellish-chat test regex <regex> <test>`** Compiles a regex pattern and tests it against a string for debugging purposes.
-* **`/embellish-chat test stress <count> <test>`** Simulates `<count>` messages to stress-test the server's processing performance.
+* **`/embellish-chat stress_test <count> <text>`** Simulates `<count>` messages to stress-test the server's message-processing performance. *(Max: 5000 messages, player-only execution).*
 
 ### User Commands
 > Available to **all players** (no permission required).
 
-* **`/mebellish-chat open <player>`** Opens the last shared inventory of the specified player.
-* **`/mebellish-chat help mention`** Displays the list of available mention targets and usage guides.
-* **`/mebellish-chat help style`** Displays the list of available styles, presets, and syntax guides.
-* **`/mebellish-chat notification`** Toggles your personal mention notification preferences. *(This command is controlled by `notificationCommandEnable` in the configuration).*
+* **`/embellish-chat open <player|uuid>`** Opens the last shared inventory/ender chest/item snapshot of the specified player.
+* **`/embellish-chat help mention`** Displays the mention rules available to you based on your permissions.
+* **`/embellish-chat help style`** Displays the styling rules available to you based on your permissions.
+* **`/embellish-chat notification`** Toggles your personal mention notification preferences. *(Enabled/disabled globally by `notificationCommandEnable` in the config).*
 
 ---
 
@@ -106,7 +105,7 @@ The configuration file is located at `config/embellish-chat/config.json`.
 ```
 {
   //version
-  "version": "3.1.0",
+  "version": "3.1.1",
   
   //preset
   "colorPreset": { ... },

--- a/docs/mkdocs/docs/index.md
+++ b/docs/mkdocs/docs/index.md
@@ -51,26 +51,25 @@ Use these patterns directly in the chat window.
 
 ## Commands
 
-### User Commands (`/ec`)
+### User Commands (`/embellish-chat`)
 Available to all players.
 
 | Command            | Description                                                              |
 |:-------------------|:-------------------------------------------------------------------------|
-| `/ec help style`   | Displays available styles and syntax usage.                              |
-| `/ec help mention` | Displays available mention types and targets.                            |
-| `/ec notification` | Toggles personal mention notifications (if enabled in config).           |
-| `/ec open`         | Opens the last shared inventory/ender chest/item of the specified player |
+| `/embellish-chat help style`   | Displays available styles and syntax usage.                              |
+| `/embellish-chat help mention` | Displays available mention types and targets.                            |
+| `/embellish-chat notification` | Toggles personal mention notifications (if enabled in config).           |
+| `/embellish-chat open <player\|uuid>` | Opens the last shared inventory/ender chest/item snapshot of the specified player |
 
 ### Admin Commands (`/embellish-chat`)
 Requires OP Level 2 or appropriate permissions.
 
 | Command       | Arguments        | Description                                           |
 |:--------------|:-----------------|:------------------------------------------------------|
-| `reload`      | `None`           | Reloads `config/embellish-chat.json`.                 |
+| `reload`      | `None`           | Reloads all files under `config/embellish-chat/`.                 |
 | `ban`         | `<player>`       | Blocks a player from using mod features.              |
 | `pardon`      | `<player>`       | Restores mod access for a player.                     |
-| `test regex`  | `<regex> <test>` | Tests a regex pattern against a string.               |
-| `test stress` | `<count> <test>` | Simulates `<count>` messages for performance testing. |
+| `stress_test` | `<count> <text>` | Simulates `<count>` messages for performance testing. |
 
 ---
 ## Configuration
@@ -82,7 +81,7 @@ The configuration file is located at `config/embellish-chat/config.json`.
 ```
 {
   //version
-  "version": "3.1.0",
+  "version": "3.1.1",
   
   //preset
   "colorPreset": { ... },

--- a/docs/mkdocs/docs/style/StyleType.md
+++ b/docs/mkdocs/docs/style/StyleType.md
@@ -70,7 +70,7 @@
     * Displays the supplied text when the mouse hovers over it.
     * **Option:** `Text`
 * `HOVER_ITEM`
-    * Displays the item description for a specified inventoryContext slot when hovered over. (e.g., `-1` for main-hand, `40` for off-hand).
+    * Displays the item description for a specified inventory slot when hovered over. (e.g., `-1` for main-hand, `40` for off-hand).
     * **Option:** `Slot ID`
 * `URL`
     * Opens the provided URL in a browser when clicked.
@@ -108,16 +108,16 @@
 * `SHOW_ITEM`
     * Displays the description and texture of the item/block held by the player.
     * This style type must be placed at the very bottom.
-    * **Option:** `Altas Path(atlas;sprite)`
+    * **Option:** `Atlas Path (atlas;sprite)`
 * `SHOW_INVENTORY`
-    * Displays the user’s face. Clicking it shows the user’s inventoryContext snapshot.
+    * Displays the user’s face. Clicking it shows the user’s inventory snapshot.
     * This style type must be placed at the very bottom.
-    * The inventoryContext snapshot is cleared when the player leaves the server.
+    * The inventory snapshot is cleared when the player leaves the server.
     * **Option:** `None`
 * `SHOW_ENDER_CHEST`
     * Displays the user’s face. Clicking it shows the user’s ender chest snapshot.
     * This style type must be placed at the very bottom.
-    * The inventoryContext snapshot is cleared when the player leaves the server.
+    * The inventory snapshot is cleared when the player leaves the server.
     * **Option:** `None`
 * `ATLAS_PRESET`
     * Uses a predefined atlas name from the `atlasPreset` section.


### PR DESCRIPTION
### Motivation

- Bring the repository documentation in line with the actual runtime behavior and command tree implemented in the codebase so users see accurate command names, arguments, and config defaults.
- Fix minor terminology/typos in the style docs and update the default config version to match the project metadata.

### Description

- Replaced legacy `/ec` references with the implemented command root `/embellish-chat` in `docs/README.md` and `docs/mkdocs/docs/index.md`.
- Updated admin/user command descriptions to reflect the real implementation: changed the stress command to `stress_test <count> <text>`, clarified `open <player|uuid>` usage, and clarified reload behavior to "Reloads all files under `config/embellish-chat/`."
- Bumped the example config `version` in docs from `3.1.0` to `3.1.1` to match the current project version metadata.
- Corrected wording/typos in `docs/mkdocs/docs/style/StyleType.md` (`inventoryContext` -> `inventory`, `Altas` -> `Atlas`) and clarified a few option descriptions.

### Testing

- Verified the documentation edits and local diffs to ensure the updated text matches the in-code commands and comments (diff review succeeded).
- Attempted to run a build check with `bash ./gradlew classes`, which failed in this environment because the `fabric-loom:1.15-SNAPSHOT` plugin could not be resolved from the configured repositories; this is an environment resolution issue and not related to the docs changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7a4caac4832f836b9bb3978865d6)