### PR TITLE
Update web config generator to support new config fields (commandAlias, rule comments)

### DIFF
--- a/docs/mkdocs/docs/config-generator.html
+++ b/docs/mkdocs/docs/config-generator.html
@@ -57,7 +57,7 @@
 
     // Default config.json
     const DEFAULT_CONFIG = {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "colorPreset": {
         "dark green": "#00AA00",
         "green": "#55FF55",
@@ -86,6 +86,7 @@
       },
       "delimiter": ",",
       "timestamp": "yyyy-MM-dd HH:mm:ss",
+      "commandAlias": "",
       "urlColor": "#0000EE",
       "defaultTeamColor": "#FF55FF",
       "notificationCommandEnable": true,
@@ -487,6 +488,12 @@
                     onChange={(v) => updateGlobal('timestamp', v)}
                     placeholder="yyyy-MM-dd HH:mm:ss"
                 />
+                <Input
+                    label="Command Alias (/ec 대신 사용할 별칭)"
+                    value={config.commandAlias || ""}
+                    onChange={(v) => updateGlobal('commandAlias', v)}
+                    placeholder="Leave empty to keep /embellish-chat only"
+                />
                 <div className="flex flex-col gap-3">
                     <div className="flex items-center space-x-3 pt-2">
                         <input
@@ -665,6 +672,16 @@
                                         className="font-mono text-sm"
                                         placeholder="e.g. \*\*([^\*]+)\*\*()"
                                     />
+                                    <Input
+                                        label="Comment (/embellish-chat help style)"
+                                        value={rule.comment || ""}
+                                        onChange={(v) => {
+                                            const newRules = [...rules];
+                                            newRules[idx] = { ...newRules[idx], comment: v };
+                                            updateRuleList('stylingRules', permKey, newRules);
+                                        }}
+                                        placeholder="<blue><b>Pattern</b></blue>: **Text** ..."
+                                    />
                                     <StyleActionsEditor
                                         actions={rule.styles}
                                         onChange={(newActions) => {
@@ -680,7 +697,7 @@
                             className="w-full mt-4"
                             variant="secondary"
                             onClick={() => {
-                                const newRules = [...rules, { pattern: "", styles: [] }];
+                                const newRules = [...rules, { pattern: "", styles: [], comment: "" }];
                                 updateRuleList('stylingRules', permKey, newRules);
                             }}
                         >
@@ -837,6 +854,18 @@
                                             className="md:col-span-6"
                                         />
 
+                                        <Input
+                                            label="Comment (/embellish-chat help mention)"
+                                            value={rule.comment || ""}
+                                            onChange={(v) => {
+                                                const newRules = [...rules];
+                                                newRules[idx] = { ...newRules[idx], comment: v };
+                                                updateRuleList('mentionRules', permKey, newRules);
+                                            }}
+                                            className="md:col-span-6"
+                                            placeholder="<blue><b>Pattern</b></blue>: @everyone ..."
+                                        />
+
                                         <div className="md:col-span-12 bg-slate-50 dark:bg-slate-900/30 p-3 rounded">
                                             <MentionActionsEditor
                                                 actions={rule.mentions}
@@ -877,7 +906,8 @@
                                             pitch: 1.0
                                         },
                                         mentions: [],
-                                        styles: []
+                                        styles: [],
+                                        comment: ""
                                     }];
                                     updateRuleList('mentionRules', permKey, newRules);
                                 }}
@@ -1006,10 +1036,18 @@
                     if (parsed.mentionBroadcast === undefined) parsed.mentionBroadcast = true;
                     if (parsed.webhook === undefined) parsed.webhook = "";
                     if (parsed.useClearFormat === undefined) parsed.useClearFormat = false;
+                    if (parsed.commandAlias === undefined) parsed.commandAlias = "";
                     if (parsed.atlasPreset === undefined) parsed.atlasPreset = {};
                     setConfig(parsed);
                 } else if (fileType === "styles") {
                     const parsed = JSON.parse(stylesJson);
+                    if (parsed.stylingRules) {
+                        Object.keys(parsed.stylingRules).forEach(key => {
+                            parsed.stylingRules[key].forEach(rule => {
+                                if (rule.comment === undefined) rule.comment = "";
+                            });
+                        });
+                    }
                     setStyles(parsed);
                 } else if (fileType === "mentions") {
                     const parsed = JSON.parse(mentionsJson);
@@ -1023,6 +1061,7 @@
                                     rule.sound = { id: rule.sound, category: "UI", volume: 1.0, pitch: rule.pitch || 1.0 };
                                     delete rule.pitch;
                                 }
+                                if (rule.comment === undefined) rule.comment = "";
                             });
                         });
                     }


### PR DESCRIPTION
### Motivation
- Bring the web-based config editor in `docs/mkdocs/docs/config-generator.html` in line with the updated runtime config shape so generated defaults and the editor UI match the expected structure.
- Allow server admins to configure the new `commandAlias` and to provide per-rule `comment` text that is shown in `/embellish-chat help` outputs.

### Description
- Bumped the web editor `DEFAULT_CONFIG.version` from `3.1.0` to `3.1.1` and added a `commandAlias` default key to the default config JSON.
- Added a `Command Alias` input field to the Global settings UI to let users edit `commandAlias` from the web generator.
- Added `comment` inputs to both the Styling and Mention rule editors, included `comment` on new rule creation, and adjusted rule objects to include `comment: ""` by default.
- Enhanced JSON import/migration logic to backfill missing `commandAlias` and per-rule `comment` fields when loading older configs or style/mention files.

### Testing
- Verified the code changes by inspecting the patch/diff with `git diff` which shows the new defaults and UI changes; inspection succeeded.
- Launched a local static server using `python3 -m http.server --directory docs/mkdocs/docs` to serve the updated page which started (PID reported) indicating files are reachable.
- Attempted an automated UI screenshot with Playwright to validate the UI, but the browser crashed (SIGSEGV) in this environment so the capture step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dbb62c6e4832f8143bce0791542d0)